### PR TITLE
Reset password with powershell

### DIFF
--- a/resetPasswords.ps1
+++ b/resetPasswords.ps1
@@ -24,5 +24,8 @@ foreach($acc in $hashes) {
 
 function resetPassword($username) {
 	#This probably doesn't work. Needs testing
-	Set-User $username -ChangePasswordAtLogon $true 
+	#Set-User $username -ChangePasswordAtLogon $true
+	$tempPassword = "walkingsoftwareblueelephant"
+	Set-ADAccountPassword -Identity $username -Reset -NewPassword $tempPassword
+	Set-ADUser -Identity $username -ChangePasswordAtLogon $true 
 }


### PR DESCRIPTION
Replaced set-user with powershell commands:
set-adaccountpassword and set-aduser

Also, added variable in function for temporary password to set temporary password for the user.